### PR TITLE
fix: add string as return for getCover and make sure to not pass false to fseek

### DIFF
--- a/src/Mp3Info.php
+++ b/src/Mp3Info.php
@@ -233,7 +233,7 @@ class Mp3Info {
     
 
     /**
-     * @return bool|null
+     * @return bool|null|string
      */
     public function getCover()
     {
@@ -242,6 +242,9 @@ class Mp3Info {
         }
 
         $fp = fopen($this->_fileName, 'rb');
+        if ($fp === false) {
+            return false;
+        }
         fseek($fp, $this->coverProperties['offset']);
         $data = fread($fp, $this->coverProperties['size']);
         fclose($fp);


### PR DESCRIPTION
Hi and thanks for your useful library!

- string was missing as return value.
- the check for false is a hardening. it's super unlikely as we just read the file to fetch the data but to make static code analysis happy ;)
