### PR TITLE
fix: generate exception if codec/layer versions or channel headers are unrecognized

### DIFF
--- a/src/Mp3Info.php
+++ b/src/Mp3Info.php
@@ -384,6 +384,9 @@ class Mp3Info {
             case 0b11: $this->layerVersion = self::LAYER_1; break;
         }
 
+        if (!isset($this->codecVersion) || !isset($this->layerVersion) || !isset($header_bytes[2])) {
+            throw new \Exception('Unknown codecVersion or layerVersion!');
+        }
         $this->bitRate = self::$_bitRateTable[$this->codecVersion][$this->layerVersion][$header_bytes[2] >> 4];
         $this->sampleRate = self::$_sampleRateTable[$this->codecVersion][($header_bytes[2] >> 2) & 0b11];
 

--- a/src/Mp3Info.php
+++ b/src/Mp3Info.php
@@ -385,7 +385,7 @@ class Mp3Info {
         }
 
         if (!isset($this->codecVersion) || !isset($this->layerVersion) || !isset($header_bytes[2])) {
-            throw new \Exception('Unknown codecVersion or layerVersion!');
+            throw new \Exception('Unrecognized codecVersion or layerVersion headers!');
         }
         $this->bitRate = self::$_bitRateTable[$this->codecVersion][$this->layerVersion][$header_bytes[2] >> 4];
         $this->sampleRate = self::$_sampleRateTable[$this->codecVersion][($header_bytes[2] >> 2) & 0b11];
@@ -397,6 +397,9 @@ class Mp3Info {
             case 0b11: $this->channel = self::MONO; break;
         }
 
+        if (!isset($this->channel)) {
+            throw new \Exception('Unrecognized channel header!');
+        }
         $vbr_offset = self::$_vbrOffsets[$this->codecVersion][$this->channel == self::MONO ? 0 : 1];
 
         // check for VBR

--- a/src/Mp3Info.php
+++ b/src/Mp3Info.php
@@ -373,7 +373,6 @@ class Mp3Info {
 
         switch ($header_bytes[1] >> 3 & 0b11) {
             case 0b00: $this->codecVersion = self::MPEG_25; break;
-            case 0b01: $this->codecVersion = self::CODEC_UNDEFINED; break;
             case 0b10: $this->codecVersion = self::MPEG_2; break;
             case 0b11: $this->codecVersion = self::MPEG_1; break;
         }


### PR DESCRIPTION
Thanks (once again) for the useful library we use over at the Nextcloud project!

While looking into nextcloud/server#44573, I noted we might as well throw an informative exception if the `codecVersion`,  `layerVersion`, or  `channel` headers are unrecognized. 

We're going to error out anyway when we try to use empty values for the array key. Instead of generating generic PHP errors when we go to set the `bitRate` and `sampleRate` or `vbr_offset` we can leave the user a bit less confused about the underlying cause.

I don't even know what MP3s might cause this, but seems reasonable to handle this situation cleanly if possible. :)